### PR TITLE
added additional signInWithPopup method to fix signInWithProvider problem in web app

### DIFF
--- a/lib/src/provider.dart
+++ b/lib/src/provider.dart
@@ -47,12 +47,10 @@ class OidcProvider extends OAuthProvider {
             rawNonce: token.rawNonce,
           ),
         );
+      } else if (kIsWeb) {
+        credential = await auth.signInWithPopup(firebaseAuthProvider);
       } else {
-        if (kIsWeb) {
-          credential = await auth.signInWithPopup(firebaseAuthProvider);
-        } else {
-          credential = await auth.signInWithProvider(firebaseAuthProvider);
-        }
+        credential = await auth.signInWithProvider(firebaseAuthProvider);
       }
     } catch (err) {
       authListener.onError(err);

--- a/lib/src/provider.dart
+++ b/lib/src/provider.dart
@@ -48,7 +48,11 @@ class OidcProvider extends OAuthProvider {
           ),
         );
       } else {
-        credential = await auth.signInWithProvider(firebaseAuthProvider);
+        if (kIsWeb) {
+          credential = await auth.signInWithPopup(firebaseAuthProvider);
+        } else {
+          credential = await auth.signInWithProvider(firebaseAuthProvider);
+        }
       }
     } catch (err) {
       authListener.onError(err);


### PR DESCRIPTION
This package works well in mobile app but web app produces error "signInWithProvider() is not implemented". 

I believe this is expected as official documents suggests to use signInWithPopup for other oauth sign in methods such as for Microsoft and Twitter. https://github.com/firebase/flutterfire/blob/master/docs/auth/federated-auth.md#microsoft 

